### PR TITLE
Improve grammar in docs

### DIFF
--- a/Doc/gomisbcoredoc/docs/KLV/klv.md
+++ b/Doc/gomisbcoredoc/docs/KLV/klv.md
@@ -8,10 +8,10 @@
 
 ![KLV](./KLV_640x480.jpg)
 
-**MISBCore** SDK has a KLV encoder / decoder library integrated, so for generic **STANAG 4609** metadata related tasks there is no need to deal with it explicitly - user either provides KLV encoded data buffer (at the client side) and gets the decoded metadata back or (at the server/encoder side) supplies the structured (as json) metadata and receives a KLV encoded data buffer.
+**MISBCore** SDK has an integrated KLV encoder/decoder library, so for generic **STANAG 4609** metadata tasks there is no need to deal with KLV explicitly—the user either provides a KLV‑encoded data buffer on the client side and gets the decoded metadata back, or on the server side supplies structured (JSON) metadata and receives a KLV‑encoded buffer.
 
 ## Encoding/decoding metadata for Unmanned Air System (UAS)
-Unmanned Air Systems use two types of KLV encoded metadata. Universal Data Set (UDS) - the 16-byte key, basic encoding rules (BER) formatted length, and data value is appropriate for applications where bandwidth isn't a concern. However, transmitting the 16-byte universal key quickly uses up the available bandwidth. UAS airborne platforms use a wireless communications channel where the bandwidth allocated for metadata is limited. Because of the bandwidth disadvantages of using a Universal Data Set, it is more desirable to use a Local Data Set for transmission over a UAS Datalink. Local Data Set can use a 1, 2 or 4-byte key with a 1, 2, 4-byte, or BER encoded length. For more info about KLV use in UAS application see [KLV in UAS applications](./klv-in-uas.md)
+Unmanned Air Systems use two types of KLV‑encoded metadata. Universal Data Set (UDS)—the 16‑byte key with basic encoding rules (BER) formatted length and data value—is suitable where bandwidth is not a concern. However, transmitting the 16‑byte universal key quickly consumes available bandwidth. UAS platforms typically use wireless channels where bandwidth for metadata is limited. Because of this, it is preferable to use a Local Data Set for transmission over a UAS datalink. A Local Data Set can use a 1, 2, or 4‑byte key with a 1‑, 2‑, 4‑byte, or BER‑encoded length. For more information about using KLV in UAS applications, see [KLV in UAS applications](./klv-in-uas.md)
 
 
 

--- a/Doc/gomisbcoredoc/docs/KLV/klvi-int-stanag4609.md
+++ b/Doc/gomisbcoredoc/docs/KLV/klvi-int-stanag4609.md
@@ -4,7 +4,7 @@ The MPEG-2 Transport Stream provides an infrastructure for the carriage of video
 
 ![KLV](./KLV_640x480.jpg)
 
-Below you can see some usefull information from the standards that define methods to time stamp compressed video streams and to transport video and metadata asynchronously or synchronously in compressed motion imagery streams. Implementation methods are defined that leverage the transport layer of MPEG-2 for carriage of motion imagery streams of varying types and bit rates as defined in the Motion Imagery Standards Profile concept of “X on 2”. Specific compressed video formats covered include MPEG-2 and H.264.
+Below is some useful information from the standards that define methods to timestamp compressed video streams and to transport video and metadata asynchronously or synchronously in compressed motion imagery streams. Implementation methods leverage the transport layer of MPEG-2 for carriage of motion imagery streams of varying types and bit rates, as described in the Motion Imagery Standards Profile concept of “X on 2.” Specific compressed video formats covered include MPEG‑2 and H.264.
 
 ## Anatomy of a STANAG 4609 stream
 

--- a/Doc/gomisbcoredoc/docs/KLV/stanag4609.md
+++ b/Doc/gomisbcoredoc/docs/KLV/stanag4609.md
@@ -12,7 +12,7 @@ The MPEG-2 Transport Stream provides an infrastructure for the carriage of video
 
 ![KLV](./KLV_640x480.jpg)
 
-Below you can see some usefull information from the standards that define methods to time stamp compressed video streams and to transport video and metadata asynchronously or synchronously in compressed motion imagery streams. Implementation methods are defined that leverage the transport layer of MPEG-2 for carriage of motion imagery streams of varying types and bit rates as defined in the Motion Imagery Standards Profile concept of “X on 2”. Specific compressed video formats covered include MPEG-2 and H.264.
+Below is some useful information from the standards that define methods to timestamp compressed video streams and to transport video and metadata asynchronously or synchronously in compressed motion imagery streams. Implementation methods leverage the transport layer of MPEG‑2 for carriage of motion imagery streams of varying types and bit rates, as described in the Motion Imagery Standards Profile concept of “X on 2.” Specific compressed video formats covered include MPEG‑2 and H.264.
 
 ## Anatomy of a STANAG 4609 stream
 

--- a/Doc/gomisbcoredoc/docs/ST806/pluginDevelopment.md
+++ b/Doc/gomisbcoredoc/docs/ST806/pluginDevelopment.md
@@ -5,7 +5,7 @@ Plugins allow you to extend the functionality of **User Defined Data** encoder a
 
 ## Plugins location
 
-**MisbCore** will try to locate plugins in a **./plugins** sub directory, so the installation is basically a coping the plugin binaries to this directory.
+**MisbCore** looks for plugins in a **./plugins** sub-directory, so installation simply involves copying the plugin binaries into this directory.
 
 
 ## Rvt User Defined data plugin

--- a/Doc/gomisbcoredoc/docs/ST806/st806.md
+++ b/Doc/gomisbcoredoc/docs/ST806/st806.md
@@ -108,9 +108,9 @@ The content of the **User-Defined LS** is determined out of the field.
 Bits 1 to 6 of the Numeric ID for Data Type define the **descriptive key**, which in its turn defines the data type.  
 
 
-### Using arbitrary byte array
-This method allows passing arbitrary binary data. SDK in that case is data agnostic, it just passed the data from server to the client. It is a client responsibility to decode and interpret the data.
-To pass the binary data, we use byte array encoded as base64 string.
+### Using an arbitrary byte array
+This method allows passing arbitrary binary data. The SDK is data agnostic in this case—it simply passes the data from the server to the client. It is the client's responsibility to decode and interpret the data.
+To pass the binary data, use a byte array encoded as a base64 string.
 
 >Note, **MISBCore** will extract the byte array and send binary data (and not the base64 encoded string)! 
 
@@ -162,7 +162,7 @@ At the client side, in order to get the data back, we decode the packet using **
 
 
 
-For example, lets define a **User-Defined LS** and assign it a GUID, to make it unique:  
+For example, let's define a **User-Defined LS** and assign it a GUID to make it unique:
 
 Sample User Data Local Set:  
 

--- a/Doc/gomisbcoredoc/docs/ST806/stplayer-rvt-user-defined.md
+++ b/Doc/gomisbcoredoc/docs/ST806/stplayer-rvt-user-defined.md
@@ -1,10 +1,10 @@
-Plugins allow you to extend the functionality of **StPlayer** without any modification to the application.  
+Plugins allow you to extend the functionality of **StPlayer** without modifying the application.
 
-**StPlayer**> will look for existing plugins (and try to enumerate and load them) in the C:\Program Files\ImpleoTV\StPlayer\Bin\x64\plugins directory (if installed with defaults).
+**StPlayer** will look for existing plugins (and try to enumerate and load them) in the `C:\Program Files\ImpleoTV\StPlayer\Bin\x64\plugins` directory (if installed with the defaults).
 
-So, installing new plugins is basically copying the plugins dlls into this folder.
+Installing a new plugin simply requires copying the plugin DLLs into this folder.
 
-You can see installed plugins in the Options->Plugins
+You can view installed plugins in **Options > Plugins**
 
 ![Plugins](./Plugins.png)
 
@@ -12,7 +12,7 @@ You can see installed plugins in the Options->Plugins
 # Using RvtUserDefinedData plugin
 
 Each plugin implements its specific functionality.  
-For example, if user doesn't have **RvtUserDefinedData** plugin installed, **StPlayer** will show User defined RVT data as a data buffer.
+For example, if a user doesn't have the **RvtUserDefinedData** plugin installed, **StPlayer** will show user-defined RVT data as a data buffer.
 
 ![Compact form](./RvtWithoutPlugin.png)
 

--- a/Doc/gomisbcoredoc/docs/user-guide/decoding-601.md
+++ b/Doc/gomisbcoredoc/docs/user-guide/decoding-601.md
@@ -56,7 +56,7 @@ Console.WriteLine(jsonStr);
 
 ## Options
 
-**MisbCore SDK** has some configuration options you may want to use to fine-tune it's behavior.
+**MisbCore SDK** has several configuration options you can use to fine-tune its behavior.
 
 - **TimeStampAsDateTime** property - set it to **true** in order to get the timestamps in a **ISO 8601** format. Default - *false*
 - **RoundValues** property - set it to **true** in order to get the values rounded to the accuracy defined in the standard. Default - *true*


### PR DESCRIPTION
## Summary
- refine plugin documentation wording
- clarify StPlayer plugin usage text
- polish ST806 explanation of binary data
- fix typos in KLV overview docs
- clarify configuration options

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68467ea7f4408333912dc4afcbf64b1a